### PR TITLE
Fix running on Windows

### DIFF
--- a/lib/functions/outdated-packages.dart
+++ b/lib/functions/outdated-packages.dart
@@ -9,8 +9,9 @@ import 'package:dart_lens/models/outdated-packages/outdated-packages.dart';
 Future<OutdatedPackages?> runFlutterPubOutdated(
   String projectDirectoryPath,
 ) async {
+  final flutterCmd = Platform.isWindows ? 'flutter.bat' : 'flutter';
   final flutterPubOutdatedResult = await Process.run(
-    'flutter',
+    flutterCmd,
     [
       'pub',
       'outdated',

--- a/lib/functions/packages.dart
+++ b/lib/functions/packages.dart
@@ -44,8 +44,9 @@ Future<void> applyPackageVersionChanges(
 }
 
 Future<void> runFlutterPubGet(String directoryPath) async {
+  final flutterCmd = Platform.isWindows ? 'flutter.bat' : 'flutter';
   final flutterPubGetProcess = await Process.run(
-    'flutter',
+    flutterCmd,
     ['pub', 'get'],
     workingDirectory: directoryPath,
   );

--- a/lib/functions/project-structure-analysis.dart
+++ b/lib/functions/project-structure-analysis.dart
@@ -19,7 +19,8 @@ Future<List<ResolvedUnitResult>> getProjectStructure(
   // NOTE: on macOS, App Sandbox must be disabled for this to work
 
   // run `flutter doctor -v`
-  final flutterDoctorResult = await Process.run('flutter', ['doctor', '-v']);
+  final flutterCmd = Platform.isWindows ? 'flutter.bat' : 'flutter';
+  final flutterDoctorResult = await Process.run(flutterCmd, ['doctor', '-v']);
   // extract flutter sdk path from flutter doctor output
   // example to look for: Flutter version <version> on channel <channel> at <path>
   final flutterSdkPathRegex =


### PR DESCRIPTION
On Windows, Process.run cannot run a .bat file (like flutter.bat) without using the file extension.